### PR TITLE
Add swindow = 0 support for sampling from the primary censored distributions.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # primarycensoreddist 0.1.0.1000
 
+
+## Package
+
+* Added support for `swindow = 0` to `rprimarycensoreddist` to allow for non-secondary event censored distributions.
 # primarycensoreddist 0.1.0
 
 This is the initial `primarycensoreddist` release and includes R and stan tools for dealing with potentially truncated primary event censored delay distributions. We expect all current features to work but the UI may change as the package matures over the next few versions.

--- a/R/rprimarycensoreddist.R
+++ b/R/rprimarycensoreddist.R
@@ -11,6 +11,9 @@
 #' @param rdist Function to generate random samples from the delay distribution
 #' for example [stats::rlnorm()] for lognormal distribution.
 #'
+#' @param swindow Integer specifying the window size for rounding the delay
+#' (default is 1). If `swindow = 0` then no rounding is applied.
+#'
 #' @param n Number of random samples to generate.
 #'
 #' @param rprimary Function to generate random samples from the primary
@@ -24,7 +27,7 @@
 #' @param ... Additional arguments to be passed to the distribution function.
 #'
 #' @return Vector of random samples from the primary event censored
-#' distribution
+#' distribution censored by the secondary event window.
 #'
 #' @aliases rpcens
 #'
@@ -75,7 +78,11 @@ rprimarycensoreddist <- function(n, rdist, pwindow = 1, swindow = 1,
   total_delay <- p + delay
 
   # Round to the nearest swindow
-  rounded_delay <- floor(total_delay / swindow) * swindow
+  if (swindow > 0) {
+    rounded_delay <- floor(total_delay / swindow) * swindow
+  } else {
+    rounded_delay <- total_delay
+  }
 
   # Apply truncation and select valid samples
   valid_samples <- rounded_delay[rounded_delay >= 0 & rounded_delay < D]

--- a/man/rprimarycensoreddist.Rd
+++ b/man/rprimarycensoreddist.Rd
@@ -37,7 +37,8 @@ for example \code{\link[stats:Lognormal]{stats::rlnorm()}} for lognormal distrib
 
 \item{pwindow}{Primary event window}
 
-\item{swindow}{Secondary event window (default: 1)}
+\item{swindow}{Integer specifying the window size for rounding the delay
+(default is 1). If \code{swindow = 0} then no rounding is applied.}
 
 \item{D}{Maximum delay (truncation point). If finite, the distribution is
 truncated at D. If set to Inf, no truncation is applied. Defaults to Inf.}
@@ -54,7 +55,7 @@ samples to account for truncation (default is 1.2).}
 }
 \value{
 Vector of random samples from the primary event censored
-distribution
+distribution censored by the secondary event window.
 }
 \description{
 This function generates random samples from a primary event censored

--- a/tests/testthat/test-rprimarycensoreddist.R
+++ b/tests/testthat/test-rprimarycensoreddist.R
@@ -36,3 +36,27 @@ test_that("rprimarycensoreddist handles very truncated distributions", {
 
   expect_true(all(samples >= 0 & samples < D))
 })
+
+test_that(
+  "rprimarycensoreddist supports non-secondary event censored distributions",
+  {
+    n <- 1000
+    pwindow <- 5
+    D <- 10
+    swindow <- 0
+
+    samples <- rpcens(
+      n, rlnorm, pwindow,
+      swindow = swindow,
+      D = D, meanlog = 0, sdlog = 1
+    )
+
+    expect_true(all(samples >= 0 & samples < D))
+
+    # Check that samples are not rounded to discrete intervals
+    expect_false(all(samples == floor(samples)))
+
+    # Check that at least some samples have fractional parts
+    expect_true(any(samples != floor(samples)))
+  }
+)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR is unlinked to a issue but relates to functionality discussed in `epidist` (https://github.com/epinowcast/epidist/pull/273). This allows sampling from primary censored distributions that are not secondary censored.

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
