### PR TITLE
use local environment for `fitdist` call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Suggests:
     rmarkdown,
     spelling,
     testthat (>= 3.1.9),
-    usethis
+    usethis,
+    withr
 Additional_repositories:
     https://stan-dev.r-universe.dev
 Config/Needs/hexsticker: hexSticker, sysfonts, ggplot2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,12 @@ Authors@R:
            family = "Howes",
            role = c("ctb"),
            email = "adamthowes@gmail.com",
-           comment = c(ORCID = "0000-0003-2386-4031")))
+           comment = c(ORCID = "0000-0003-2386-4031")),
+    person(given = "Sebastian",
+           family = "Funk",
+           role = c("ctb"),
+           email = "sebastian.funk@lshtm.ac.uk",
+           comment = c(ORCID = "0000-0002-2842-3406")))
 Description: This package provides both R functions for working with primary
     event censored distributions and Stan implementations for use in Bayesian
     modeling. Primary event censored distributions are useful for modeling

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ This is the development version of `primarycensoreddist` and is not yet ready fo
 ## Package
 
 * Split "Why it works" vignette into two separate vignettes, "Why it works" and "Analytic solutions for censored delay distributions".
+* Removed the need to assign functions to the global environment for `fitdistdoublecens()` by using `withr`.
 
 # primarycensoreddist 0.5.0
 

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -114,16 +114,12 @@ fitdistdoublecens <- function(censdata, distr,
   }
   formals(ppcens_dist) <- formals(pdist)
 
-  assign("d.pcens_dist", dpcens_dist, envir = .GlobalEnv)
-  assign("p.pcens_dist", ppcens_dist, envir = .GlobalEnv)
-
   # Fit the distribution
-  fit <- fitdistrplus::fitdist(
+  fit <- withr::with_environment(environment(), fitdistrplus::fitdist(
     censdata$left,
-    distr = ".pcens_dist",
+    distr = "pcens_dist",
     ...
-  )
-  rm(dpcens_dist, ppcens_dist)
+  ))
   return(fit)
 }
 


### PR DESCRIPTION
With reference to https://github.com/epinowcast/primarycensoreddist/issues/62#issuecomment-2353255911 shouldn't this work? (tested locally it does but might be missing some complexity).